### PR TITLE
Dependency check aggregate2

### DIFF
--- a/examples/my-jwt-framework-support-example/subproject.build.gradle
+++ b/examples/my-jwt-framework-support-example/subproject.build.gradle
@@ -1,4 +1,15 @@
 
 dependencies {
-    compile project(':frameworks:my-jwt-framework-support')
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.0") {
+		force = true // so that there is a security issue
+    }
+
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.0") {
+        because 'previous versions have security issues'
+    }
+	
+	implementation project(':frameworks:my-jwt-framework-support')
+    
+
+    
 }

--- a/examples/my-jwt-framework-support-example/subproject.build.gradle
+++ b/examples/my-jwt-framework-support-example/subproject.build.gradle
@@ -4,10 +4,6 @@ dependencies {
 		force = true // so that there is a security issue
     }
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.0") {
-        because 'previous versions have security issues'
-    }
-	
 	implementation project(':frameworks:my-jwt-framework-support')
     
 


### PR DESCRIPTION
**./gradlew clean dependencyCheckAggregate**

> Task :my-jwt:dependencyCheckAggregate
Verifying dependencies for project my-jwt
Checking for updates and analyzing dependencies for vulnerabilities
Generating report for project my-jwt
Found 4 vulnerabilities in project my-jwt


One or more dependencies were identified with known vulnerabilities:

my-jwt-framework-support.jar (project :frameworks:my-jwt-framework-support): ids:(cpe:/a:jwt_project:jwt:1.0.0, org.gradle.my.example:my-jwt-framework-support:1.0.0) : CVE-2016-7037
jackson-databind-2.9.0.jar: ids:(cpe:/a:fasterxml:jackson-databind:2.9.0, com.fasterxml.jackson.core:jackson-databind:2.9.0, cpe:/a:fasterxml:jackson:2.9.0) : CVE-2017-15095, CVE-2018-5968, CVE-2018-7489


See the dependency-check report for more details.



> Task :examples:my-jwt-framework-support-example:dependencyCheckAggregate
Verifying dependencies for project my-jwt-framework-support-example
Checking for updates and analyzing dependencies for vulnerabilities
Generating report for project my-jwt-framework-support-example
Found 4 vulnerabilities in project my-jwt-framework-support-example


One or more dependencies were identified with known vulnerabilities:

my-jwt-framework-support.jar (project :frameworks:my-jwt-framework-support): ids:(cpe:/a:jwt_project:jwt:1.0.0, org.gradle.my.example:my-jwt-framework-support:1.0.0) : CVE-2016-7037
jackson-databind-2.9.0.jar: ids:(cpe:/a:fasterxml:jackson-databind:2.9.0, com.fasterxml.jackson.core:jackson-databind:2.9.0, cpe:/a:fasterxml:jackson:2.9.0) : CVE-2017-15095, CVE-2018-5968, CVE-2018-7489


See the dependency-check report for more details.



> Task :frameworks:my-jwt-framework-support:dependencyCheckAggregate
Verifying dependencies for project my-jwt-framework-support
Checking for updates and analyzing dependencies for vulnerabilities
Generating report for project my-jwt-framework-support
Found 4 vulnerabilities in project my-jwt-framework-support


One or more dependencies were identified with known vulnerabilities:

my-jwt-framework-support.jar (project :frameworks:my-jwt-framework-support): ids:(cpe:/a:jwt_project:jwt:1.0.0, org.gradle.my.example:my-jwt-framework-support:1.0.0) : CVE-2016-7037
jackson-databind-2.9.0.jar: ids:(cpe:/a:fasterxml:jackson-databind:2.9.0, com.fasterxml.jackson.core:jackson-databind:2.9.0, cpe:/a:fasterxml:jackson:2.9.0) : CVE-2017-15095, CVE-2018-5968, CVE-2018-7489


See the dependency-check report for more details.



Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 5s
6 actionable tasks: 6 executed